### PR TITLE
[DNM] Swap to npm, use same version as bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "ember-cli-summernote",
   "dependencies": {
-    "summernote": "0.8.3"
   }
 }

--- a/index.js
+++ b/index.js
@@ -9,12 +9,11 @@ module.exports = {
 
   included: function(app) {
     this._super.included(app);
-
-    var summernotePath   = path.join(app.bowerDirectory,'/summernote/dist/');
-    var bootstrapPath   = path.join(app.bowerDirectory,'/bootstrap/dist/');
+    var summernotePath   = path.join('node_modules/summernote/dist/');
+    var bootstrapPath   = path.join('node_modules/bootstrap/dist/');
 
     // DBG.
-    var options         = app.options['ember-cli-summernote'] || {};  // This options are from the ember-cli-build.js
+    // var options         = app.options['ember-cli-summernote'] || {};  // This options are from the ember-cli-build.js
     // console.log(`index.js: options: ${JSON.stringify(app.options['ember-cli-summernote'])}`);
 
     var projectConfig = this.project.config(app.env); // This projectConfig is from the consuming app's environment.js
@@ -33,7 +32,12 @@ module.exports = {
     // Include Summernote.
     app.import(path.join(summernotePath, 'summernote.css'));
     if (!process.env.EMBER_CLI_FASTBOOT) {
-      app.import(path.join(summernotePath, 'summernote.min.js'));
+      // app.import(path.join(summernotePath, 'summernote.js'), {
+      //   using: [
+      //     { transformation: 'amd', as: 'summernote' }
+      //   ]
+      // });
+      app.import(path.join(summernotePath, 'summernote.js'));
     }
     app.import(path.join(summernotePath, 'font/summernote.eot'), { destDir: 'assets/font' });
     app.import(path.join(summernotePath, 'font/summernote.ttf'), { destDir: 'assets/font' });

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "deploy": "ember github-pages:commit --message \"Deploy gh-pages from commit $(git rev-parse HEAD)\"; git push; git checkout -"
   },
   "dependencies": {
-    "ember-cli-babel": "^6.0.0"
+    "ember-cli-babel": "^6.0.0",
+    "summernote": "0.8.3"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",


### PR DESCRIPTION
I still need to verify that this will work in non-engine world, but pretty sure it will.

Let's leave this open until I'm sure no other changes are needed... currently this is loading in engines, and I've verified that it's there as `$.summernote` but... it no render. :(